### PR TITLE
Refactor settlement logic using client based bot for settlement

### DIFF
--- a/programs/matching_engine/src/errors.rs
+++ b/programs/matching_engine/src/errors.rs
@@ -14,4 +14,8 @@ pub enum ErrorCode {
     InsufficientBalance,
     #[msg("Overflow")]
     Overflow,
+    #[msg("Already settled")]
+    AlreadySettled,
+    #[msg("Unauthorized settlement")]
+    UnauthorizedSettlement,
 }

--- a/programs/matching_engine/src/instructions/arcium/match_order_callback.rs
+++ b/programs/matching_engine/src/instructions/arcium/match_order_callback.rs
@@ -15,12 +15,9 @@ pub struct MatchOrdersCallback<'info> {
 }
 
 #[event]
-pub struct TradeExecutedEvent {
-    pub match_id: u64,
-    pub buyer: Pubkey,
-    pub seller: Pubkey,
-    pub base_mint: Pubkey,
-    pub quote_mint: Pubkey,
-    pub quantity: u64,
-    pub execution_price: u64,
+pub struct EncryptedMatchesEvent {
+    pub computation_offset: Pubkey,
+    pub ciphertext: [[u8; 32]; 1466],  // Encrypted match data
+    pub nonce: u128,
+    pub timestamp: i64,
 }

--- a/programs/matching_engine/src/instructions/execute_settlement.rs
+++ b/programs/matching_engine/src/instructions/execute_settlement.rs
@@ -13,7 +13,7 @@ pub fn execute_settlement(
     quantity: u64,
     execution_price: u64,
 ) -> Result<()> {
-    // Verify settlement authority (bot)
+    // Verify settlement authority (settlement bot)
     require!(
         ctx.accounts.settlement_authority.key() == SETTLEMENT_BOT_PUBKEY,
         ErrorCode::UnauthorizedSettlement
@@ -67,7 +67,6 @@ pub fn execute_settlement(
         quote_amount,
     )?;
     
-    // Mark as settled
     ctx.accounts.match_record.is_settled = true;
     ctx.accounts.match_record.settlement_timestamp = Clock::get()?.unix_timestamp;
     
@@ -87,8 +86,9 @@ pub fn execute_settlement(
 #[instruction(match_id: u64)]
 pub struct ExecuteSettlement<'info> {
     #[account(mut)]
-    pub settlement_authority: Signer<'info>,  // Authorized bot
-    
+    pub settlement_authority: Signer<'info>,  
+
+    /// CHECK: PDA authority for vault
     #[account(
         seeds = [b"vault_authority"],
         bump,

--- a/programs/matching_engine/src/instructions/execute_settlement.rs
+++ b/programs/matching_engine/src/instructions/execute_settlement.rs
@@ -1,0 +1,131 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
+use crate::errors::ErrorCode;
+use crate::states::MatchRecord;
+
+const SETTLEMENT_BOT_PUBKEY: Pubkey =  pubkey!("11111111111111111111111111111111");
+// not the vault authority but a separate authority that can only execute settlements.
+// the vault authority is the one that can execute deposits and withdrawals which is a pda derived from the main program.
+
+pub fn execute_settlement(
+    ctx: Context<ExecuteSettlement>,
+    match_id: u64,
+    quantity: u64,
+    execution_price: u64,
+) -> Result<()> {
+    // Verify settlement authority (bot)
+    require!(
+        ctx.accounts.settlement_authority.key() == SETTLEMENT_BOT_PUBKEY,
+        ErrorCode::UnauthorizedSettlement
+    );
+    
+    // Prevent double settlement
+    require!(
+        !ctx.accounts.match_record.is_settled,
+        ErrorCode::AlreadySettled
+    );
+    
+    let quote_amount = quantity
+        .checked_mul(execution_price)
+        .ok_or(ErrorCode::Overflow)?;
+    
+    // Transfer base tokens: seller → buyer
+    let base_transfer_cpi = Transfer {
+        from: ctx.accounts.seller_base_vault.to_account_info(),
+        to: ctx.accounts.buyer_base_vault.to_account_info(),
+        authority: ctx.accounts.vault_authority.to_account_info(),
+    };
+    
+    let vault_auth_bump = ctx.bumps.vault_authority;
+    let signer_seeds: &[&[&[u8]]] = &[&[
+        b"vault_authority",
+        &[vault_auth_bump],
+    ]];
+    
+    token::transfer(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            base_transfer_cpi,
+            signer_seeds,
+        ),
+        quantity,
+    )?;
+    
+    // Transfer quote tokens: buyer → seller
+    let quote_transfer_cpi = Transfer {
+        from: ctx.accounts.buyer_quote_vault.to_account_info(),
+        to: ctx.accounts.seller_quote_vault.to_account_info(),
+        authority: ctx.accounts.vault_authority.to_account_info(),
+    };
+    
+    token::transfer(
+        CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            quote_transfer_cpi,
+            signer_seeds,
+        ),
+        quote_amount,
+    )?;
+    
+    // Mark as settled
+    ctx.accounts.match_record.is_settled = true;
+    ctx.accounts.match_record.settlement_timestamp = Clock::get()?.unix_timestamp;
+    
+    emit!(SettlementExecutedEvent {
+        match_id,
+        buyer: ctx.accounts.buyer_base_vault.owner,
+        seller: ctx.accounts.seller_base_vault.owner,
+        quantity,
+        execution_price,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+    
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(match_id: u64)]
+pub struct ExecuteSettlement<'info> {
+    #[account(mut)]
+    pub settlement_authority: Signer<'info>,  // Authorized bot
+    
+    #[account(
+        seeds = [b"vault_authority"],
+        bump,
+    )]
+    pub vault_authority: UncheckedAccount<'info>,
+    
+    #[account(
+        init_if_needed,
+        payer = settlement_authority,
+        space = 8 + MatchRecord::INIT_SPACE,
+        seeds = [b"match_record", match_id.to_le_bytes().as_ref()],
+        bump,
+    )]
+    pub match_record: Account<'info, MatchRecord>,
+    
+    // Buyer vaults
+    #[account(mut)]
+    pub buyer_base_vault: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub buyer_quote_vault: Account<'info, TokenAccount>,
+    
+    // Seller vaults
+    #[account(mut)]
+    pub seller_base_vault: Account<'info, TokenAccount>,
+    #[account(mut)]
+    pub seller_quote_vault: Account<'info, TokenAccount>,
+    
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+}
+
+#[event]
+pub struct SettlementExecutedEvent {
+    pub match_id: u64,
+    pub buyer: Pubkey,
+    pub seller: Pubkey,
+    pub quantity: u64,
+    pub execution_price: u64,
+    pub timestamp: i64,
+}

--- a/programs/matching_engine/src/instructions/mod.rs
+++ b/programs/matching_engine/src/instructions/mod.rs
@@ -18,3 +18,6 @@ pub use withdraw::*;
 
 pub mod initialize_vault;
 pub use initialize_vault::*;
+
+pub mod execute_settlement;
+pub use execute_settlement::*;

--- a/programs/matching_engine/src/lib.rs
+++ b/programs/matching_engine/src/lib.rs
@@ -68,7 +68,12 @@ pub mod matching_engine {
             _ => return Err(ErrorCode::AbortedComputation.into()),
         };
 
-        // TODO: Handle matches
+        emit!(EncryptedMatchesEvent {
+            computation_offset: ctx.accounts.comp_def_account.key(),
+            ciphertext: matches.ciphertexts,  // Raw encrypted bytes
+            nonce: matches.nonce,
+            timestamp: Clock::get()?.unix_timestamp,
+        });
 
         Ok(())
     }

--- a/programs/matching_engine/src/lib.rs
+++ b/programs/matching_engine/src/lib.rs
@@ -105,6 +105,11 @@ pub mod matching_engine {
         instructions::withdraw_from_vault(ctx, amount)?;
         Ok(())
     }
+
+    pub fn execute_settlement(ctx: Context<ExecuteSettlement>, match_id: u64, quantity: u64, execution_price: u64) -> Result<()> {
+        instructions::execute_settlement(ctx, match_id, quantity, execution_price)?;
+        Ok(())
+    }
 }
 
 #[error_code]

--- a/programs/matching_engine/src/states/match_record.rs
+++ b/programs/matching_engine/src/states/match_record.rs
@@ -1,0 +1,9 @@
+use anchor_lang::prelude::*;
+
+#[account]
+#[derive(InitSpace)]
+pub struct MatchRecord {
+    pub match_id: u64,
+    pub is_settled: bool,
+    pub settlement_timestamp: i64,
+}

--- a/programs/matching_engine/src/states/mod.rs
+++ b/programs/matching_engine/src/states/mod.rs
@@ -6,3 +6,6 @@ pub use order_account::*;
 
 pub mod vault_state;
 pub use vault_state::*;
+
+pub mod match_record;
+pub use match_record::*;


### PR DESCRIPTION
 Addresses: #1 

The callback function should emit the `SharedEncryptedStruct` object in an event and this will be recieved by our backend service to keep log and funrthermore trigger the final settlement procedure using the `execute_settlement` instruction handler that will be exclusively called by a settlement bot at regular intervals of time.
  
The settlement bot is not a good solution here, for the MVP let's stick to this methodology.